### PR TITLE
workshop 01: add Binder repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# This uses the latest Docker image built from the samples repository,
+# defined by the Dockerfile in Build/images/samples.
+FROM mcr.microsoft.com/quantum/samples:latest
+
+# Mark that this Dockerfile is used with the samples repository.
+ENV IQSHARP_HOSTING_ENV=SAMPLES_HOSTED
+
+# Make sure the contents of our repo are in ${HOME}.
+# These steps are required for use on mybinder.org.
+USER root
+COPY . ${HOME}
+RUN chown -R ${USER} ${HOME}
+
+# Finish by dropping back to the notebook user.
+USER ${USER}

--- a/workshop 01 - Introduction to Quantum Computing/README.md
+++ b/workshop 01 - Introduction to Quantum Computing/README.md
@@ -1,5 +1,7 @@
 # Introduction to Quantum Computing
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/qpower-msp/Workshops/master)
+
 A shallow dive into the world of Quantum Computing! We explore what Quantum can
 achieve, what makes it better than it's classical counterpart? After convincing
 you all, we have made a special hands-on experience session, tailored for you :)


### PR DESCRIPTION
Convert our workshop to binder repo to enable our audience follow the
hands-on demonstration on their PCs.